### PR TITLE
Fix pipeline bugs across annotation, normalization, filtering, and se…

### DIFF
--- a/modules/annotation.py
+++ b/modules/annotation.py
@@ -9,6 +9,19 @@ from scimilarity.src.scimilarity.utils import lognorm_counts
 from scimilarity.src.scimilarity import CellAnnotation, align_dataset
 
 
+def _resolve_input(afile):
+    """Resolve the CSV input file and sample name from either a CSV file
+    path (e.g. ``.../<gsm>/<gsm>.csv``) or the sample directory that
+    contains it (e.g. ``.../<gsm>``)."""
+    if os.path.isfile(afile):
+        count_file = os.path.basename(afile)
+        if count_file.endswith(".csv"):
+            count_file = count_file[:-4]
+        return afile, count_file
+    count_file = os.path.basename(afile.rstrip("/\\"))
+    return f"{afile}/{count_file}.csv", count_file
+
+
 class AnnotationHuman:
     def __init__(self, annotation_path, python_module_path):
         """
@@ -39,8 +52,7 @@ class AnnotationHuman:
         """
         specie = kwargs.get('specie', 'human')
         output_dir = kwargs.get('output_dir', os.path.join(os.getcwd(), "annotated_data"))
-        count_file = os.path.basename(afile)
-        input_file = f"{afile}/{count_file}.csv"
+        input_file, count_file = _resolve_input(afile)
         outfile_dir = f"{output_dir}/{specie}/{count_file}"
         tmpfile = f"{output_dir}/{specie}/{count_file}.tmp"
 
@@ -145,9 +157,8 @@ class AnnotationMouse:
         """
         specie = kwargs.get('specie', 'mouse')  # Default specie is 'mouse'
         output_dir = kwargs.get('output_dir', os.path.join(os.getcwd(), "annotated_data"))
-        count_file = os.path.basename(afile)  # Extract filename
 
-        input_file = f"{afile}/{count_file}.csv"
+        input_file, count_file = _resolve_input(afile)
         outfile_dir = f"{output_dir}/{specie}/{count_file}"
         tmpfile = f"{output_dir}/{specie}/{count_file}.tmp"
 
@@ -290,9 +301,8 @@ class AnnotationOtherSpecie:
         """
         specie = kwargs.get('specie')
         output_dir = kwargs.get('output_dir', os.path.join(os.getcwd(), "annotated_data"))
-        count_file = os.path.basename(afile)
 
-        input_file = f"{afile}/{count_file}.csv"
+        input_file, count_file = _resolve_input(afile)
         outfile_dir = f"{output_dir}/{specie}/{count_file}"
         tmpfile = f"{output_dir}/{specie}/{count_file}.tmp"
         homologous_gene_dir = os.path.join(kwargs.get('homologous_gene_dir'), f"human2{specie}.csv")

--- a/modules/annotation_filter.py
+++ b/modules/annotation_filter.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime
 import pandas as pd
 import numpy as np

--- a/modules/gene_data_filter.py
+++ b/modules/gene_data_filter.py
@@ -68,7 +68,8 @@ class Filter:
         """
         adata.obs['mito_total'] = adata[:, adata.var_names.str.startswith('MT-')].X.sum(axis=1)
         adata.obs['percent_mito'] = adata.obs['mito_total'] / adata.X.sum(axis=1)
-        return adata[adata.obs['percent_mito'] < self.percent_mt_max]
+        # percent_mito is a fraction (0-1); percent_mt_max is expressed as a percentage.
+        return adata[adata.obs['percent_mito'] < self.percent_mt_max / 100]
 
     @staticmethod
     def filter_gene_variance(adata, mt_list):

--- a/modules/gene_data_normalization.py
+++ b/modules/gene_data_normalization.py
@@ -148,8 +148,9 @@ class GeneDataNormalization:
     def process(self, afile, cut_max_len=-1, **kwargs):
         """Main function to process the data."""
         output_dir = kwargs.get('output_dir', os.path.join(os.getcwd(), "normalization_data"))
-        h5ad_data_path = os.path.join(output_dir, self.specie, os.path.basename(afile).replace('.csv', '.h5ad'))
-        outfile_dir = os.path.join(output_dir, f"hf/{self.specie}".rsplit('/', 1)[0])
+        gsm = os.path.basename(afile).replace('.csv', '')
+        h5ad_data_path = os.path.join(output_dir, self.specie, f"{gsm}.h5ad")
+        outfile_dir = os.path.join(output_dir, "hf", self.specie, gsm)
         tmpfile = f"{outfile_dir}.tmp"
 
         if os.path.exists(outfile_dir):
@@ -169,11 +170,13 @@ class GeneDataNormalization:
         adata.write(h5ad_data_path)
 
         tokens = self.load_tokens()
-        cut_max_len = min(cut_max_len, adata.shape[1])
+        if cut_max_len is None or cut_max_len < 0:
+            cut_max_len = adata.shape[1]
+        else:
+            cut_max_len = min(cut_max_len, adata.shape[1])
         input_genes, input_ids, lengths, values = self.transform_data(adata, tokens, cut_max_len)
 
-        dataset = self.export_to_huggingface(adata, lengths, input_genes, input_ids, values,
-                                             outfile_dir.split('/')[-1])
+        dataset = self.export_to_huggingface(adata, lengths, input_genes, input_ids, values, gsm)
         self.save_dataset(outfile_dir, dataset, lengths)
 
         os.unlink(tmpfile)

--- a/modules/sex_determine.py
+++ b/modules/sex_determine.py
@@ -49,14 +49,15 @@ class HumanSexDetermine(SexDetermine):
         gender_determine_result = pd.DataFrame(columns=["Sample ID", "Gender"])
 
         for idx in range(sample_x_gene.shape[0]):
-            if (sample_y_gene.loc[idx, 'ratioY'] >= 0.001188).all():
+            ratio_x = sample_x_gene.iloc[idx]['ratioX']
+            ratio_y = sample_y_gene.iloc[idx]['ratioY']
+            if ratio_y >= 0.001188:
                 gender = "Male"
-            elif (sample_x_gene.loc[idx, 'ratioX'] <= 0.000070).all() and (sample_y_gene.loc[idx, 'ratioY'] > 0.000106).all():
+            elif ratio_x <= 0.000070 and ratio_y > 0.000106:
                 gender = "Male"
-            elif (sample_x_gene.loc[idx, 'ratioX'] >= 0.000001).all() and (sample_y_gene.loc[idx, 'ratioY'] <= 0.000106).all():
+            elif ratio_x >= 0.000001 and ratio_y <= 0.000106:
                 gender = "Female"
-            elif (sample_x_gene.loc[idx, 'ratioX'] > 0.000070).all() and (0.000106 < sample_y_gene.loc[idx, 'ratioY']).all() and (
-                    sample_y_gene.loc[idx, 'ratioY'] <= 0.001188).all():
+            elif ratio_x > 0.000070 and 0.000106 < ratio_y <= 0.001188:
                 gender = "Mix"
             else:
                 gender = "unknown"
@@ -82,18 +83,17 @@ class MouseSexDetermine(SexDetermine):
         gender_determine_result = pd.DataFrame(columns=["Sample ID", "Gender"])
 
         for idx in range(sample_x_gene.shape[0]):
-            if (sample_y_gene.loc[idx, 'ratioY'] >= 0.000065).all():
+            ratio_x = sample_x_gene.iloc[idx]['ratioX']
+            ratio_y = sample_y_gene.iloc[idx]['ratioY']
+            if ratio_y >= 0.000065:
                 gender = "Male"
-            elif (sample_x_gene.loc[idx, 'ratioX'] <= 0.000008).all() and (sample_y_gene.loc[idx, 'ratioY'] > 0.000004).all() and (
-                    sample_y_gene.loc[idx, 'ratioY'] < 0.000065).all():
+            elif ratio_x <= 0.000008 and 0.000004 < ratio_y < 0.000065:
                 gender = "Male"
-            elif (sample_x_gene.loc[idx, 'ratioX'] >= 0.000555).all() and (sample_y_gene.loc[idx, 'ratioY'] > 0.000004).all() and (
-                    sample_y_gene.loc[idx, 'ratioY'] < 0.000065).all():
+            elif ratio_x >= 0.000555 and 0.000004 < ratio_y < 0.000065:
                 gender = "Female"
-            elif (sample_x_gene.loc[idx, 'ratioX'] > 0).all() and (sample_y_gene.loc[idx, 'ratioY'] <= 0.000004).all():
+            elif ratio_x > 0 and ratio_y <= 0.000004:
                 gender = "Female"
-            elif (0.000008 < sample_x_gene.loc[idx, 'ratioX']).all() and (sample_x_gene.loc[idx, 'ratioX'] < 0.000555).all() and (
-                    0.000004 < sample_y_gene.loc[idx, 'ratioY']).all() and (sample_y_gene.loc[idx, 'ratioY'] < 0.000065).all():
+            elif 0.000008 < ratio_x < 0.000555 and 0.000004 < ratio_y < 0.000065:
                 gender = "Mix"
             else:
                 gender = "unknown"


### PR DESCRIPTION
…x determination

- annotation_filter: add missing `import sys` (NameError on construction)
- annotation: accept CSV file or sample dir as input so the annotate step actually finds its input (main.py/README feed file paths, not dirs)
- gene_data_normalization: fix hf output path collapsing all files into one dir (only first file was processed); derive per-file gsm names
- gene_data_normalization: treat default cut_max_len=-1 as "no cap" instead of truncating every cell
- gene_data_filter: compare mito fraction against percent_mt_max/100 so the MT-percentage filter is no longer a no-op
- sex_determine: use positional .iloc instead of label .loc to avoid KeyError on named-index data