### PR TITLE
Fix pipeline bugs and enable vendored scimilarity import

### DIFF
--- a/modules/annotation.py
+++ b/modules/annotation.py
@@ -5,6 +5,12 @@ import pandas as pd
 import anndata as ad
 import datetime
 import rpy2.robjects as robjects
+
+# Make the vendored ``scimilarity`` package importable as a top-level module
+# (it lives at ``modules/scimilarity``). This must happen before the imports
+# below, which run at module load time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 from scimilarity.src.scimilarity.utils import lognorm_counts
 from scimilarity.src.scimilarity import CellAnnotation, align_dataset
 

--- a/modules/scimilarity/src/scimilarity/cell_annotation.py
+++ b/modules/scimilarity/src/scimilarity/cell_annotation.py
@@ -339,7 +339,7 @@ class CellAnnotation(CellEmbedding):
                 celltype_weighted = defaultdict(float)
                 for neighbor, dist in zip(nns, d_nns):
                     celltype[self.idx2label[neighbor]] += 1
-                    celltype_weighted[self.idx2label[neighbor]] += 1 / dist
+                    celltype_weighted[self.idx2label[neighbor]] += float(1 / dist)
                 # predict based on consensus max occurrence
                 if weighting:
                     predictions.append(


### PR DESCRIPTION
## Summary
修复 pipeline 各步骤中的多个 bug，并让本地 vendored 的 scimilarity 包无需 pip install 即可 import。

## Bug fixes
- **annotation_filter.py**: `sys` 未 import 导致构造时 `NameError`
- **annotation.py**: annotate 步骤把 CSV 文件路径当目录处理，导致静默跳过；新增 `_resolve_input()` 兼容文件/目录两种输入
- **gene_data_normalization.py**: `hf` 输出路径塌缩导致只处理第一个文件；默认 `cut_max_len=-1` 截断每个 cell
- **gene_data_filter.py**: 线粒体百分比阈值（分数 vs 百分比）比较错误，过滤形同虚设
- **sex_determine.py**: 位置索引配 `.loc` 标签访问，命名索引数据下 `KeyError`；改用 `.iloc`
- **annotation.py**: 在模块加载前把 `modules/` 加入 `sys.path`，使顶层 `scimilarity` 解析到本地 vendored 包
- **cell_annotation.py**: kNN 预测统计中 `np.float32` 权重无法被 `json.dumps` 序列化，转为原生 float

## Testing
- 全部模块 `py_compile` 通过
- 确认 `scimilarity` / `scimilarity.src.scimilarity` 解析到本地 `modules/scimilarity`
- 未做端到端运行（需 scanpy / rpy2+R / scimilarity 依赖及 gene_data 参考数据）