### PR TITLE
Fix merge step reading cell-type files from filter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ python main.py \
   --species human \
   --steps merge \
   --project-root /path/to/scCompass \
-  --filter-output /path/to/outputs/filtered_data \
+  --annotate-output /path/to/outputs/annotated_data \
   --map-output /path/to/outputs/mapping_data \
   --merge-output /path/to/outputs/merged_data \
   --metadata-path /path/to/metadata
 ```
+
+`merge` pairs each sample's cell-type labels (from the annotate step) with its
+mapped count matrix (from the map step), so both `--annotate-output` and
+`--map-output` must point at the directories produced by those steps.
 
 `--metadata-path` must contain `<species>.xlsx` (for example `human.xlsx`) with at least the `Organ` column.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -80,11 +80,15 @@ python main.py \
   --species human \
   --steps merge \
   --project-root /path/to/scCompass \
-  --filter-output /path/to/outputs/filtered_data \
+  --annotate-output /path/to/outputs/annotated_data \
   --map-output /path/to/outputs/mapping_data \
   --merge-output /path/to/outputs/merged_data \
   --metadata-path /path/to/metadata
 ```
+
+`merge` 会把每个样本的细胞类型标签（来自 annotate 步骤）与其映射后的计数矩阵
+（来自 map 步骤）配对，因此 `--annotate-output` 与 `--map-output` 都必须指向对应
+步骤实际产出的目录。
 
 `--metadata-path` 目录下需要包含 `<species>.xlsx`（例如 `human.xlsx`），并至少包含 `Organ` 列。
 

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def gene_mapping_pipeline(input_pattern: str, species_name: str, output_dir: str
 
 
 def gene_merging_pipeline(
-    filter_dir: str,
+    annotation_dir: str,
     mapping_dir: str,
     species_name: str,
     output_dir: str,
@@ -94,7 +94,7 @@ def gene_merging_pipeline(
 ) -> None:
     from modules import SpeciesDataProcessor
 
-    merge_instance = SpeciesDataProcessor(species_name, filter_dir, mapping_dir, output_dir, metadata_path)
+    merge_instance = SpeciesDataProcessor(species_name, annotation_dir, mapping_dir, output_dir, metadata_path)
     merge_instance()
 
 
@@ -171,7 +171,7 @@ def main() -> None:
             if not args.metadata_path:
                 raise ValueError("--metadata-path is required when step includes 'merge'")
             gene_merging_pipeline(
-                args.filter_output,
+                args.annotate_output,
                 args.map_output,
                 args.species,
                 args.merge_output,

--- a/modules/gene_merge.py
+++ b/modules/gene_merge.py
@@ -6,12 +6,15 @@ import pandas as pd
 
 
 class SpeciesDataProcessor:
-    def __init__(self, specie_name, filter_dir, mapping_dir, merge_dir, metadata_path):
+    def __init__(self, specie_name, annotation_dir, mapping_dir, merge_dir, metadata_path):
         """
         Initialize the class with paths and the species name.
+
+        ``annotation_dir`` is the annotation output root; it holds the
+        ``<sample>_cell_type.csv`` files this step consumes.
         """
         self.specie_name = specie_name
-        self.filter_dir = os.path.join(filter_dir, specie_name)
+        self.annotation_dir = os.path.join(annotation_dir, specie_name)
         self.mapping_dir = os.path.join(mapping_dir, specie_name)
         self.merge_dir = os.path.join(merge_dir, specie_name)
         self.metadata_path = metadata_path
@@ -52,10 +55,13 @@ class SpeciesDataProcessor:
             sample_name = index
             organ_name = re.sub(r'\s', '', row["Organ"])
 
-            sample_cell_type_dir = f"{self.filter_dir}/{sample_name}"
+            sample_cell_type_dir = f"{self.annotation_dir}/{sample_name}"
             sample_gene_mapping_dir = f"{self.mapping_dir}/{sample_name}"
 
-            if not (os.path.exists(sample_cell_type_dir) and os.path.exists(sample_gene_mapping_dir)):
+            cell_type_file = f"{sample_cell_type_dir}/{sample_name}_cell_type.csv"
+            cell_mapping_file = f"{sample_gene_mapping_dir}/{sample_name}.csv"
+
+            if not (os.path.exists(cell_type_file) and os.path.exists(cell_mapping_file)):
                 continue
 
             sample_num += 1
@@ -64,9 +70,6 @@ class SpeciesDataProcessor:
 
             print(out_str)
             self.write_logs(self.merge_dir, out_str)
-
-            cell_type_file = f"{sample_cell_type_dir}/{sample_name}_cell_type.csv"
-            cell_mapping_file = f"{sample_gene_mapping_dir}/{sample_name}.csv"
 
             try:
                 cell_types = pd.read_csv(cell_type_file, header=None)


### PR DESCRIPTION
## Summary

The `merge` step was pointed at the **filter** output directory to locate
per-sample cell-type files, but `<sample>_cell_type.csv` is only produced by
the **annotate** step. As a result `merge` never found the labels: the old
directory-only existence check passed (filter does create the sample dir), then
`pd.read_csv` raised `FileNotFoundError`, which the surrounding
`except pd.errors.EmptyDataError` does not catch — crashing the run.

## Changes

- `main.py`: the `merge` branch now passes `args.annotate_output` (not
  `args.filter_output`) as the cell-type source; `gene_merging_pipeline`'s
  first parameter renamed `filter_dir` → `annotation_dir` to match.
- `modules/gene_merge.py`: constructor parameter/attribute renamed
  `filter_dir` → `annotation_dir`; the existence guard now checks the two
  actual input files (`_cell_type.csv` and the mapped matrix) up front, so a
  missing file cleanly `continue`s instead of crashing.
- `README.md` / `README_zh.md`: the merge example now uses `--annotate-output`,
  with a note that merge pairs annotate's cell-type labels with map's count
  matrix.

## Testing

- `python -m compileall main.py modules/gene_merge.py` passes.