### PR TITLE
Fix merge IndexError and correct map-step docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ mapped count matrix (from the map step), so both `--annotate-output` and
 - `--steps`: steps to run, any combination of `filter normalize annotate map merge`
 - `--project-root`: project root containing `gene_data/` and `modules/`
 - `--input-pattern`: input CSV glob (required for `filter`)
-- `--filtered-pattern`: filtered CSV glob (required for `normalize`/`annotate`)
-- `--annotated-pattern`: annotated CSV glob (required for `map`)
+- `--filtered-pattern`: filtered CSV glob (required for `normalize`/`annotate`/`map`)
 - `--annotation-model-path`: annotation model path
 - `--metadata-path`: metadata directory for `merge`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,7 +69,7 @@ python main.py \
   --species human \
   --steps map \
   --project-root /path/to/scCompass \
-  --filter-output "/path/to/outputs/filtered_data/human/*/*.csv" \
+  --filtered-pattern "/path/to/outputs/filtered_data/human/*/*.csv" \
   --map-output /path/to/outputs/mapping_data
 ```
 
@@ -98,8 +98,7 @@ python main.py \
 - `--steps`: 要执行的步骤，支持组合：`filter normalize annotate map merge`
 - `--project-root`: 项目根目录（应包含 `gene_data/` 与 `modules/`）
 - `--input-pattern`: 原始 CSV 输入 glob（`filter` 必填）
-- `--filtered-pattern`: 过滤后 CSV 输入 glob（`normalize`/`annotate` 必填）
-- `--annotated-pattern`: 注释后 CSV 输入 glob（`map` 必填）
+- `--filtered-pattern`: 过滤后 CSV 输入 glob（`normalize`/`annotate`/`map` 必填）
 - `--annotation-model-path`: 注释模型路径
 - `--metadata-path`: 合并步骤使用的元数据目录（`merge` 必填）
 

--- a/modules/gene_merge.py
+++ b/modules/gene_merge.py
@@ -72,9 +72,22 @@ class SpeciesDataProcessor:
             self.write_logs(self.merge_dir, out_str)
 
             try:
-                cell_types = pd.read_csv(cell_type_file, header=None)
-                cell_mapping_data = np.loadtxt(cell_mapping_file, delimiter=',', dtype=int)
+                # The annotation step writes this file via ``DataFrame.to_csv``
+                # with a header row and the row position as the index column,
+                # e.g. ``\n,0\n0,T-cell\n1,B-cell``. Read it back the same way
+                # so the index stays integer-typed (index column -> row number,
+                # remaining column -> predicted cell type).
+                cell_types = pd.read_csv(cell_type_file, header=0, index_col=0)
+                # A single-row mapping file loads as a 1-D array; force 2-D so
+                # row selection below stays valid.
+                cell_mapping_data = np.atleast_2d(
+                    np.loadtxt(cell_mapping_file, delimiter=',', dtype=int)
+                )
             except pd.errors.EmptyDataError:
+                self.append_line(cell_type_file, "empty_data.txt")
+                continue
+
+            if cell_types.empty:
                 self.append_line(cell_type_file, "empty_data.txt")
                 continue
 
@@ -85,16 +98,22 @@ class SpeciesDataProcessor:
     def process_cell_types(self, organ_name, cell_types_data, cell_mapping_data):
         """
         Process cell types and save the data to corresponding files.
+
+        ``cell_types_data`` is indexed by the cell's row position in the
+        mapped count matrix; its single column holds the predicted cell type.
         """
-        grouped = cell_types_data.groupby(1)
+        cell_type_column = cell_types_data.columns[0]
+        grouped = cell_types_data.groupby(cell_type_column)
         for key, group in grouped:
             print(f"Processing category: {key}")
 
-            current_cell_type = re.sub(r'\s', '', key)
+            current_cell_type = re.sub(r'\s', '', str(key))
             current_cell_type = re.sub(r'[^\w-]', '-', current_cell_type)
 
             target_merge_file = f"{self.merge_dir}/{organ_name}_{current_cell_type}.csv"
-            current_cell_type_indexes = np.array(group[0])
+            # Row positions come from the index (integer cell numbers), which is
+            # what numpy needs for row selection.
+            current_cell_type_indexes = group.index.to_numpy(dtype=int)
             current_cell_type_data = cell_mapping_data[current_cell_type_indexes, :]
 
             with open(target_merge_file, 'a', newline='') as file:


### PR DESCRIPTION
Read cell-type CSVs with the same header/index layout the annotation step writes, so row indices stay integer-typed instead of being coerced to float (which raised 'arrays used as indices must be integer or boolean type'). Group on the sole data column and take row numbers from the integer index; guard empty labels and single-row mapping matrices.

Docs: map uses --filtered-pattern (not --filter-output / the unused --annotated-pattern); fix the zh example and both parameter lists.