### PR TITLE
Run mouse annotation via external Rscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ pip install -r requirements.txt
 
 Notes:
 
-- The annotation step depends on `rpy2` and R packages (mouse annotation path).
+- Mouse annotation shells out to `Rscript scripts/mouse_annotation.R`, so a
+  local R with `Seurat`, `data.table`, `dplyr`, `ggplot2` and `scMayoMap`
+  installed must be on `PATH`. No `rpy2` is required.
 - Keep reference files under `gene_data/` (gene lists, tokens, mid values, etc.).
 
 ## 2. Directory Conventions
@@ -108,7 +110,9 @@ mapped count matrix (from the map step), so both `--annotate-output` and
 
 - `No files matched pattern`: the glob didn’t match any files; check the path and quoting.
 - `--xxx is required`: a required argument for the selected step is missing.
-- R-related errors in annotation: ensure local R and required R packages are installed.
+- R-related errors in mouse annotation: ensure `Rscript` is on `PATH` and the
+  `Seurat`, `data.table`, `dplyr`, `ggplot2`, `scMayoMap` packages are installed.
+  For batch runs outside the Python pipeline, use `scripts/annotation_mouse.sh`.
 
 ## Citation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,7 +18,9 @@ pip install -r requirements.txt
 
 说明：
 
-- 注释步骤会依赖 `rpy2` 和 R 侧包（鼠标注释路径）。
+- 鼠标（mouse）注释通过 `Rscript scripts/mouse_annotation.R` 外部调用完成，
+  因此需要本机安装 R，并安装 `Seurat`、`data.table`、`dplyr`、`ggplot2`、
+  `scMayoMap` 等 R 包，且 `Rscript` 在 `PATH` 中可用。不再依赖 `rpy2`。
 - `gene_data/` 下需要保留项目自带参考文件（基因列表、token、mid values 等）。
 
 ## 2. 目录约定

--- a/main.py
+++ b/main.py
@@ -57,7 +57,10 @@ def data_annotation_pipeline(
             python_module_path=base_dir,
         )
     elif species_name == "mouse":
-        annotation_instance = AnnotationMouse(python_module_path=base_dir)
+        annotation_instance = AnnotationMouse(
+            python_module_path=base_dir,
+            r_script_path=os.path.join(base_dir, "scripts", "mouse_annotation.R"),
+        )
     else:
         homologous_gene_dir = os.path.join(base_dir, "gene_data", "homologous_gene")
         annotation_instance = AnnotationOtherSpecie(

--- a/modules/annotation.py
+++ b/modules/annotation.py
@@ -1,10 +1,10 @@
 import os
 import sys
+import subprocess
 import scanpy as sc
 import pandas as pd
 import anndata as ad
 import datetime
-import rpy2.robjects as robjects
 
 # Make the vendored ``scimilarity`` package importable as a top-level module
 # (it lives at ``modules/scimilarity``). This must happen before the imports
@@ -136,13 +136,23 @@ class AnnotationHuman:
 
 
 class AnnotationMouse:
-    def __init__(self, python_module_path):
+    def __init__(self, python_module_path, r_script_path=None):
         """
         Initialize the class and set required paths.
+
+        ``r_script_path`` points at ``scripts/mouse_annotation.R``; it defaults
+        to the copy shipped alongside the project root (``python_module_path``).
         """
 
         # Set Python module paths
         sys.path.append(python_module_path)
+
+        # Locate the Rscript driver. Mouse annotation runs Seurat + scMayoMap
+        # through an external Rscript process rather than rpy2, so the R logic
+        # is shared with the standalone scripts/annotation_mouse.sh driver.
+        self.r_script_path = r_script_path or os.path.join(
+            python_module_path, "scripts", "mouse_annotation.R"
+        )
         print("scimilarity imported!")
 
     def write_logs(self, out_path, step_num, cell_num, success):
@@ -204,22 +214,23 @@ class AnnotationMouse:
         # Start the annotation process
         START_TIME = datetime.datetime.now()
         try:
-            # Read the input data
-            df = pd.read_csv(input_file, header=0, index_col=0)
-            print("Data loaded successfully.")
+            # Run the external Rscript. It reads the count matrix, runs the
+            # Seurat + scMayoMap pipeline, and writes
+            # ``<count_file>_cell_type.csv`` into ``outfile_dir`` itself, using
+            # a 0-based integer index so the layout matches the other-species
+            # annotation path and the downstream merge step.
+            if not os.path.exists(self.r_script_path):
+                raise FileNotFoundError(
+                    f"Mouse annotation R script not found: {self.r_script_path}"
+                )
 
-            # Execute the R script for annotation
-            r_script = self.generate_r_script(input_file)
-            r_results = robjects.r(r_script)
-
-            # Convert R output to DataFrame
-            type_res = pd.DataFrame(r_results).T
+            subprocess.run(
+                ["Rscript", self.r_script_path, input_file, outfile_dir, specie],
+                check=True,
+            )
 
             END_TIME = datetime.datetime.now()
             print(f"Time Cost: {(END_TIME - START_TIME).seconds} seconds")
-
-            # Export the annotation results
-            type_res.to_csv(os.path.join(outfile_dir, f"{count_file}_cell_type.csv"), index=True)
             print("Data exported")
 
         finally:
@@ -227,47 +238,6 @@ class AnnotationMouse:
             if os.path.exists(tmpfile):
                 os.unlink(tmpfile)
             self.write_logs(outfile_dir, "7", "-1", True)
-
-    @staticmethod
-    def generate_r_script(input_file):
-        """
-        Generate the R script for annotation with automatic package installation.
-        """
-        return f'''
-        # Load libraries
-        library(Seurat)
-        library(data.table)
-        library(dplyr)
-        library(ggplot2)
-        library(scMayoMap)
-
-        # Read and process the input data
-        count_matrix <- fread("{input_file}")
-        count_matrix2 <- t(count_matrix)
-        colnames(count_matrix2) <- count_matrix2[1, ]
-        count_matrix2 <- count_matrix2[-1, ]
-        count_matrix2 <- count_matrix2[!duplicated(rownames(count_matrix2)), ]
-        seurat.obj <- CreateSeuratObject(counts = count_matrix2)
-        seurat.obj$percent.mt <- PercentageFeatureSet(object = seurat.obj, pattern = "^mt-")
-        seurat.obj <- NormalizeData(object = seurat.obj, verbose = FALSE)
-        seurat.obj <- FindVariableFeatures(object = seurat.obj, verbose = FALSE)
-        seurat.obj <- ScaleData(object = seurat.obj, verbose = FALSE)
-        seurat.obj <- RunPCA(object = seurat.obj, verbose = FALSE)
-        seurat.obj <- FindNeighbors(object = seurat.obj, verbose = FALSE)
-        seurat.obj <- FindClusters(object = seurat.obj, verbose = FALSE)
-        seurat.markers <- FindAllMarkers(seurat.obj, method = 'MAST', verbose = FALSE)
-        scMayoMap.obj <- scMayoMap(data = seurat.markers, database = scMayoMapDatabase)
-
-        # Map cell types
-        max_col_names <- apply(scMayoMap.obj$annotation.norm, 1, function(x) colnames(scMayoMap.obj$annotation.norm)[which.max(x)])
-        seurat.obj@meta.data$celltype <- plyr::mapvalues(
-            seurat.obj@meta.data$seurat_clusters, from = names(max_col_names), to = max_col_names
-        )
-        seurat.obj@meta.data$celltype <- as.character(seurat.obj@meta.data$celltype)
-        seurat.obj@meta.data$celltype <- sapply(seurat.obj@meta.data$celltype, function(x) strsplit(x, ":")[[1]][2])
-        celltype_col <- seurat.obj@meta.data[, 'celltype', drop = FALSE]
-        celltype_col
-        '''
 
     def __call__(self, data, **kwargs):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ scanpy~=1.10.3
 pandas~=2.2.3
 anndata~=0.10.9
 scipy~=1.14.1
-rpy2~=3.5.11
 importlib-metadata~=8.5.0
 torch~=2.5.0
 networkx~=3.4.1

--- a/scripts/annotation_mouse.sh
+++ b/scripts/annotation_mouse.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Standalone mouse annotation driver.
+#
+# Runs mouse_annotation.R over every CSV under an input directory, in
+# parallel, writing one "<sample>_cell_type.csv" per sample. This is the
+# shell equivalent of the `annotate` step in main.py for mouse; it exists
+# for batch runs outside the Python pipeline.
+#
+# Usage:
+#   ./annotation_mouse.sh [input_dir] [output_dir] [species] [jobs]
+#
+# Defaults can also be overridden via the ANIMAL, INPUT_DIR, OUTPUT_DIR
+# and JOBS environment variables.
+
+set -euo pipefail
+
+# Resolve this script's directory so mouse_annotation.R is found regardless
+# of the caller's working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+R_SCRIPT="$SCRIPT_DIR/mouse_annotation.R"
+
+animal="${3:-${ANIMAL:-mouse}}"
+input_dir="${1:-${INPUT_DIR:-/mnt/cstr/celldata/h5ad/kun/csv_mouse}}"
+output_dir="${2:-${OUTPUT_DIR:-/mnt/cstr/celldata/control/data_annotation_20260701}}"
+jobs="${4:-${JOBS:-4}}"
+
+# Annotation function
+annotate_file() {
+    local file="$1"
+
+    if [ ! -f "$file" ]; then
+        echo "[ERROR] File not found: $file"
+        return
+    fi
+
+    echo "[INFO] Processing file: $file"
+    local gsm
+    gsm="$(basename "$file" .csv)"
+    local outfile_dir="$output_dir/$animal/$gsm"
+    local tmpfile="$output_dir/$animal/$gsm.tmp"
+    local outfile="$outfile_dir/${gsm}_cell_type.csv"
+    local log_file="$outfile_dir/logs.txt"
+
+    if [ -f "$outfile" ]; then
+        echo "[INFO] Annotation already completed: $file"
+        return
+    fi
+
+    if [ -f "$tmpfile" ]; then
+        echo "[INFO] Annotation already in progress: $file"
+        return
+    fi
+
+    mkdir -p "$outfile_dir"
+    touch "$tmpfile"
+    echo "Annotation Start: $(date)" >> "$log_file"
+    echo "Processing file: $file" >> "$log_file"
+
+    local start_time end_time duration
+    start_time="$(date +%s)"
+
+    if ! Rscript "$R_SCRIPT" "$file" "$outfile_dir" "$animal"; then
+        echo "[ERROR] Rscript failed for file: $file"
+        echo "Rscript failed for file: $file" >> "$log_file"
+        rm -f "$tmpfile"
+        return
+    fi
+
+    end_time="$(date +%s)"
+    duration=$((end_time - start_time))
+    echo "Annotation completed in $duration seconds"
+    echo "Annotation completed in $duration seconds" >> "$log_file"
+
+    rm -f "$tmpfile"
+}
+
+# Export function and variables for the parallel subshells.
+export -f annotate_file
+export R_SCRIPT output_dir animal
+
+# Find all target CSV files and annotate them in parallel.
+find "$input_dir" -name "*.csv" -print0 | \
+    xargs -0 -n 1 -P "$jobs" bash -c 'annotate_file "$@"' _
+
+echo "All mouse annotation tasks completed."
+exit 0

--- a/scripts/mouse_annotation.R
+++ b/scripts/mouse_annotation.R
@@ -1,0 +1,79 @@
+#!/usr/bin/env Rscript
+
+# Mouse cell-type annotation using Seurat + scMayoMap.
+#
+# Usage:
+#   Rscript mouse_annotation.R <input_csv> <outfile_dir> <species>
+#
+# Output:
+#   <outfile_dir>/<sample>_cell_type.csv
+#
+# The output layout mirrors the human/other-species annotation path
+# (modules/annotation.py): one row per cell, indexed by the cell's 0-based
+# row position in the count matrix, with a single predicted cell-type column.
+# The downstream `merge` step (modules/gene_merge.py) selects rows by that
+# integer position, so the index MUST be 0-based integers, not cell barcodes.
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+    stop("Usage: Rscript mouse_annotation.R <input_csv> <outfile_dir> [species]")
+}
+input_file <- args[1]
+outfile_dir <- args[2]
+species <- if (length(args) >= 3) args[3] else "mouse"
+
+suppressPackageStartupMessages({
+    library(Seurat)
+    library(data.table)
+    library(dplyr)
+    library(ggplot2)
+    library(scMayoMap)
+})
+
+# Read and process the input data
+cat("[INFO] Reading input file:", input_file, "\n")
+count_matrix <- fread(input_file)
+count_matrix2 <- t(count_matrix)
+colnames(count_matrix2) <- count_matrix2[1, ]
+count_matrix2 <- count_matrix2[-1, ]
+# Drop duplicated gene rows so CreateSeuratObject does not fail on
+# non-unique feature names.
+count_matrix2 <- count_matrix2[!duplicated(rownames(count_matrix2)), ]
+
+# Create Seurat object and run the standard clustering pipeline
+seurat.obj <- CreateSeuratObject(counts = count_matrix2)
+seurat.obj$percent.mt <- PercentageFeatureSet(object = seurat.obj, pattern = "^mt-")
+seurat.obj <- NormalizeData(object = seurat.obj, verbose = FALSE)
+seurat.obj <- FindVariableFeatures(object = seurat.obj, verbose = FALSE)
+seurat.obj <- ScaleData(object = seurat.obj, verbose = FALSE)
+seurat.obj <- RunPCA(object = seurat.obj, verbose = FALSE)
+seurat.obj <- FindNeighbors(object = seurat.obj, verbose = FALSE)
+seurat.obj <- FindClusters(object = seurat.obj, verbose = FALSE)
+
+# Annotation using scMayoMap
+seurat.markers <- FindAllMarkers(seurat.obj, method = 'MAST', verbose = FALSE)
+scMayoMap.obj <- scMayoMap(data = seurat.markers, database = scMayoMapDatabase)
+
+# Map clusters to cell types
+max_col_names <- apply(scMayoMap.obj$annotation.norm, 1, function(x) colnames(scMayoMap.obj$annotation.norm)[which.max(x)])
+seurat.obj@meta.data$celltype <- plyr::mapvalues(
+    seurat.obj@meta.data$seurat_clusters, from = names(max_col_names), to = max_col_names
+)
+seurat.obj@meta.data$celltype <- as.character(seurat.obj@meta.data$celltype)
+seurat.obj@meta.data$celltype <- sapply(seurat.obj@meta.data$celltype, function(x) strsplit(x, ":")[[1]][2])
+celltype_col <- seurat.obj@meta.data[, 'celltype', drop = FALSE]
+
+# Re-index by 0-based cell position and use a stable single-column layout so
+# the output matches what the Python annotation path writes for other species.
+rownames(celltype_col) <- seq_len(nrow(celltype_col)) - 1
+colnames(celltype_col) <- "0"
+
+# Save the results. basename() without an extension arg keeps the ".csv"
+# suffix, so strip it explicitly to get "<sample>_cell_type.csv".
+sample <- sub("\\.csv$", "", basename(input_file))
+if (!dir.exists(outfile_dir)) {
+    dir.create(outfile_dir, recursive = TRUE)
+}
+output_file <- file.path(outfile_dir, paste0(sample, "_cell_type.csv"))
+write.csv(celltype_col, file = output_file, row.names = TRUE)
+cat("[INFO] Data exported:", output_file, "\n")


### PR DESCRIPTION
Replace the in-process rpy2 mouse annotation with an external Rscript call. The old path transposed the R result into a 1xN frame that was not indexed by 0-based cell position, breaking the downstream merge step.

- Add scripts/mouse_annotation.R: writes <sample>_cell_type.csv indexed by 0-based integer cell position with a single column, matching the human / other-species output layout consumed by gene_merge.py. Restores the duplicated-gene guard.
- Add scripts/annotation_mouse.sh: standalone batch driver, parameterized and CWD-independent.
- AnnotationMouse now shells out via subprocess instead of rpy2; drop generate_r_script and the rpy2 import/dependency.
- Update main.py call site, requirements.txt, and both READMEs.